### PR TITLE
Signed-off-by: Nathan Weatherly nweather@redhat.com

### DIFF
--- a/charts/managed-serviceaccount/templates/manager-deployment.yaml
+++ b/charts/managed-serviceaccount/templates/manager-deployment.yaml
@@ -27,3 +27,6 @@ spec:
             {{- if .Values.featureGates }}
             - --feature-gates=EphemeralIdentity={{ .Values.featureGates.ephemeralIdentity | default false}}
             {{- end}}
+            {{- if .Values.agentImagePullSecret }}
+            - --agent-image-pull-secret={{ .Values.agentImagePullSecret }}
+            {{- end}}

--- a/charts/managed-serviceaccount/values.yaml
+++ b/charts/managed-serviceaccount/values.yaml
@@ -8,3 +8,5 @@ replicas: 1
 
 featureGates:
   ephemeralIdentity: false
+
+agentImagePullSecret: ""

--- a/e2e/framework/scheme.go
+++ b/e2e/framework/scheme.go
@@ -2,7 +2,6 @@ package framework
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"

--- a/e2e/framework/scheme.go
+++ b/e2e/framework/scheme.go
@@ -2,6 +2,7 @@ package framework
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	k8sscheme "k8s.io/client-go/kubernetes/scheme"
 	addonv1alpha1 "open-cluster-management.io/api/addon/v1alpha1"
 	clusterv1 "open-cluster-management.io/api/cluster/v1"

--- a/pkg/addon/manager/addon.go
+++ b/pkg/addon/manager/addon.go
@@ -21,10 +21,13 @@ import (
 
 var _ agent.AgentAddon = &managedServiceAccountAddonAgent{}
 
+const agentImagePullSecretName = "open-cluster-management-image-pull-credentials"
+
 func NewManagedServiceAccountAddonAgent(
 	c kubernetes.Interface,
 	imageName string,
 	agentInstallAllStrategy bool,
+	agentImagePullSecret *corev1.Secret,
 ) agent.AgentAddon {
 	var agentInstallStrategy *agent.InstallStrategy
 	agentInstallStrategy = nil
@@ -36,6 +39,7 @@ func NewManagedServiceAccountAddonAgent(
 		nativeClient:         c,
 		imageName:            imageName,
 		agentInstallStrategy: agentInstallStrategy,
+		agentImagePullSecret: agentImagePullSecret,
 	}
 }
 
@@ -43,19 +47,25 @@ type managedServiceAccountAddonAgent struct {
 	nativeClient         kubernetes.Interface
 	imageName            string
 	agentInstallStrategy *agent.InstallStrategy
+	agentImagePullSecret *corev1.Secret
 }
 
 func (m *managedServiceAccountAddonAgent) Manifests(cluster *clusterv1.ManagedCluster, addon *v1alpha1.ManagedClusterAddOn) ([]runtime.Object, error) {
 	namespace := addon.Spec.InstallNamespace
-	return []runtime.Object{
+	manifests := []runtime.Object{
 		newNamespace(namespace),
 		newServiceAccount(namespace),
 		newAddonAgentClusterRole(namespace),
 		newAddonAgentClusterRoleBinding(namespace),
 		newAddonAgentRole(namespace),
 		newAddonAgentRoleBinding(namespace),
-		newAddonAgentDeployment(cluster.Name, namespace, m.imageName),
-	}, nil
+		newAddonAgentDeployment(cluster.Name, namespace, m.imageName, m.agentImagePullSecret),
+	}
+	if m.agentImagePullSecret != nil {
+		manifests = append(manifests, newAddonAgentImagePullSecret(m.agentImagePullSecret, namespace))
+	}
+
+	return manifests, nil
 }
 
 func (m *managedServiceAccountAddonAgent) GetAgentAddonOptions() agent.AgentAddonOptions {
@@ -285,9 +295,24 @@ func newAddonAgentClusterRoleBinding(namespace string) *rbacv1.ClusterRoleBindin
 	}
 }
 
-func newAddonAgentDeployment(clusterName string, namespace string, imageName string) *appsv1.Deployment {
+func newAddonAgentImagePullSecret(agentImagePullSecret *corev1.Secret, targetNamespace string) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      agentImagePullSecretName,
+			Namespace: targetNamespace,
+		},
+		Data: agentImagePullSecret.Data,
+		Type: corev1.SecretTypeDockerConfigJson,
+	}
+}
+
+func newAddonAgentDeployment(clusterName string, namespace string, imageName string, agentImagePullSecret *corev1.Secret) *appsv1.Deployment {
 	const secretName = "managed-serviceaccount-hub-kubeconfig"
-	return &appsv1.Deployment{
+	deployment := &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",
 			Kind:       "Deployment",
@@ -347,4 +372,10 @@ func newAddonAgentDeployment(clusterName string, namespace string, imageName str
 			},
 		},
 	}
+	if agentImagePullSecret != nil {
+		deployment.Spec.Template.Spec.ImagePullSecrets = []corev1.LocalObjectReference{
+			{Name: agentImagePullSecretName},
+		}
+	}
+	return deployment
 }


### PR DESCRIPTION
add agent-image-pull-secret param to manager (#40)

if the agent image is not publicly accessible by the managed cluster image pull secret will need to be added to the managed cluster by hub addon manager via manifestwork

this PR add a new parameter and env var to the addon manager to allow user to optionally specify a reference to an image pull secret on the hub.

when this parameter is specified the content of the secret will be copied to the agent install namespace on the managed cluster and be use by agent deployment to pull the image

Signed-off-by: Hao Liu <haoli@redhat.com>