### PR TITLE
ACM-3072 Remove PodSecurity warnings from MCH Operator logs

### DIFF
--- a/charts/managed-serviceaccount/templates/manager-deployment.yaml
+++ b/charts/managed-serviceaccount/templates/manager-deployment.yaml
@@ -8,6 +8,9 @@ spec:
   selector:
     matchLabels:
       open-cluster-management.io/addon: managed-serviceaccount
+  securityContext:
+    seccompProfile:
+      type: RuntimeDefault
   template:
     metadata:
       labels:


### PR DESCRIPTION
Signed-off-by: Erin Murphy <erinmurp@redhat.com>

issue: https://issues.redhat.com/browse/ACM-3072

Description of issue: Installer team is cleaning up our logs, and require the spec seccompProfile to be set to 'RuntimeDefault' 