### PR TITLE
🌱 Ignore the default Dockerfile

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,10 +1,25 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "dockerfile": {
-        "fileMatch": [
-            "Dockerfile.rhtap"
-        ]
-    },
+    "packageRules": [
+        {
+            "matchManagers": [
+                "dockerfile"
+            ],
+            "matchFileNames": [
+                "Dockerfile"
+            ],
+            "enabled": false
+        },
+        {
+            "matchManagers": [
+                "dockerfile"
+            ],
+            "matchFileNames": [
+                "Dockerfile.rhtap"
+            ],
+            "enabled": true
+        }
+    ],
     "addLabels": [
         "ok-to-test"
     ],


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

The renovate bot still created PRs for the wrong Dockerfiles https://github.com/stolostron/managed-serviceaccount/pull/215, ignore the default Dockerfile used by the upstream

revonate config reference doc: https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#_create_your_custom_configuration

konflux default renovate config: https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json

renovate doc link to packagerules: https://docs.renovatebot.com/configuration-options/#packagerules

## Related issue(s)

Fixes #
