### PR TITLE
feat: add slack notification for managed-serviceaccount

### DIFF
--- a/.tekton/managed-serviceaccount-mce-210-push.yaml
+++ b/.tekton/managed-serviceaccount-mce-210-push.yaml
@@ -37,10 +37,6 @@ spec:
     value: true
   - name: konflux-application-name
     value: release-mce-210 # Need to be updated for each release
-  - name: slack-webhook-url-secret-name
-    value: slack-acm-server-foundation-notify-secret # do not use this secret if the component is not owned by the foundation team
-  - name: slack-webhook-url-secret-key
-    value: slack-webhook-url
   - name: slack-member-id
     value: U02CRCBPXK4 # zhujian7, The slack member id of the current component owner
   pipelineRef:


### PR DESCRIPTION
This PR adds slack notification support for the managed-serviceaccount repository.