### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for managed-serviceaccount-mce-29

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -6,7 +6,8 @@ RUN make build-bin
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL \
-    name="managed-serviceaccount" \
+    name="multicluster-engine/managed-serviceaccount-rhel9" \
+    cpe="cpe:/a:redhat:multicluster_engine:2.9::el9" \
     com.redhat.component="managed-serviceaccount" \
     description="Managed ServiceAccount is an OCM addon developed for synchronizing ServiceAccount to the \
     managed clusters and collecting the tokens from these local service accounts as secret resources back \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
