### PR TITLE
🌱 Update envtest setup to use sdk-go ensure-envtest.sh [backplane-2.6]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ export CGO_ENABLED  = 1
 export GOFLAGS ?=
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
@@ -55,12 +54,15 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-ENVTEST = $(shell pwd)/bin/setup-envtest
-setup-envtest: ## Download setup-envtest locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
 
-test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use 1.25.0 -p path)" go test ./pkg/... -coverprofile cover.out
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+test: manifests generate fmt vet envtest-setup ## Run tests.
+	go test ./pkg/... -coverprofile cover.out
 
 ##@ Build
 
@@ -119,7 +121,7 @@ endef
 images:
 	docker build -t ${IMG_REGISTRY}/managed-serviceaccount:${IMAGE_TAG} -f Dockerfile .
 
-test-integration:
+test-integration: envtest-setup
 	@echo "TODO: Run integration test"
 
 test-e2e: build-e2e


### PR DESCRIPTION
## Summary

Replace the legacy `setup-envtest` binary approach (`sigs.k8s.io/controller-runtime/tools/setup-envtest@latest` with hardcoded K8s 1.25.0) with the centralized `ensure-envtest.sh` script from `open-cluster-management-io/sdk-go`.

### Changes

- **Removed** the old `ENVTEST` variable and `setup-envtest` Makefile target that used `go-get-tool` to install the `setup-envtest` binary
- **Added** the new `envtest-setup` target that uses the `ensure-envtest.sh` script from sdk-go, which:
  - Auto-detects K8s version from `go.mod` (`k8s.io/api v0.X.Y` → `1.X.Y`)
  - Auto-detects `setup-envtest` branch from `go.mod` (`controller-runtime v0.X.Y` → `release-0.X`)
  - Caches binaries locally for faster subsequent runs
  - Uses hierarchical version fallback (exact → wildcard patch → latest)
- **Updated** the `test` target to depend on `envtest-setup` instead of `setup-envtest`
- **Updated** the `test-integration` target to depend on `envtest-setup`
- **Removed** outdated comment referencing `setup-envtest.sh`

### Reference

- Guide: https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md

## Related issue(s)

N/A