### PR TITLE
🌱 Replace legacy setup-envtest with sdk-go ensure-envtest.sh [backplane-2.8]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ testbin/*
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# envtest and tool binaries
+_output/
+
 # Kubernetes Generated files - skip generated files, except for vendored files
 # editor and IDE paraphernalia
 .idea

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ export CGO_ENABLED = 1
 export GOFLAGS ?=
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
@@ -56,12 +55,15 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-ENVTEST = $(shell pwd)/bin/setup-envtest
-setup-envtest: ## Download setup-envtest locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
 
-test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use 1.25.0 -p path)" go test ./pkg/... -coverprofile cover.out
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+test: manifests generate fmt vet envtest-setup ## Run tests.
+	go test ./pkg/... -coverprofile cover.out
 
 ##@ Build
 


### PR DESCRIPTION
## Summary

- Replace the legacy `setup-envtest` binary (installed via `go-get-tool` with hardcoded Kubernetes version `1.25.0`) with the centralized `ensure-envtest.sh` script from `open-cluster-management-io/sdk-go`
- The new approach auto-detects Kubernetes and setup-envtest versions from `go.mod`, supports three-tier version fallback, and aligns with the standard OCM envtest integration
- Add `_output/` to `.gitignore` for envtest binary caching directory

## Related issue(s)

N/A