### PR TITLE
🌱 Migrate envtest setup to sdk-go ensure-envtest.sh script [backplane-2.7]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ bin
 testbin/*
 *.test
 
+# envtest binary cache
+_output/
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ export CGO_ENABLED  = 1
 export GOFLAGS ?=
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
@@ -55,12 +54,15 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-ENVTEST = $(shell pwd)/bin/setup-envtest
-setup-envtest: ## Download setup-envtest locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
 
-test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use 1.25.0 -p path)" go test ./pkg/... -coverprofile cover.out
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+test: manifests generate fmt vet envtest-setup ## Run tests.
+	go test ./pkg/... -coverprofile cover.out
 
 ##@ Build
 


### PR DESCRIPTION
## Summary

- Replace the legacy `setup-envtest` tool (installed via `go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest`) with the centralized [`ensure-envtest.sh`](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/ensure-envtest.sh) script from `open-cluster-management-io/sdk-go`
- The new script auto-detects Kubernetes and controller-runtime versions from `go.mod`, installs `setup-envtest` matching the correct branch, and caches binaries in `_output/tools/bin`
- Add `_output/` to `.gitignore` to exclude cached envtest binaries
- Remove outdated comment referencing legacy `setup-envtest.sh`

## Changes

### Makefile
- Replaced `ENVTEST` variable and `setup-envtest` target with `ENSURE_ENVTEST_SCRIPT` URL and `envtest-setup` target
- Updated `test` target dependency from `setup-envtest` to `envtest-setup`
- `KUBEBUILDER_ASSETS` is now set via `$(eval)` from the script output instead of hardcoded version

### .gitignore
- Added `_output/` entry for envtest binary cache directory

## Related issue(s)

N/A - Infrastructure improvement following [sdk-go envtest setup guide](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md)