### PR TITLE
:seedling: Update envtest setup to use sdk-go ensure-envtest.sh [backplane-2.10]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Test binary, built with `go test -c`
 bin
 testbin/*
+_output/
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ export CGO_ENABLED = 1
 export GOFLAGS ?=
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
@@ -55,10 +54,15 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-ENVTEST = $(shell pwd)/bin/setup-envtest
-ENVTEST_K8S_VERSION = 1.35.0
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(shell pwd)/testbin -p path)" go test ./pkg/... -coverprofile cover.out
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+test: manifests generate fmt vet envtest-setup ## Run tests.
+	go test ./pkg/... -coverprofile cover.out
 
 ##@ Build
 
@@ -108,9 +112,6 @@ lister-gen: ## Download lister-gen locally if necessary.
 INFORMER_GEN = $(shell pwd)/bin/informer-gen
 informer-gen: ## Download informer-gen locally if necessary.
 	$(call go-get-tool,$(INFORMER_GEN),k8s.io/code-generator/cmd/informer-gen@v0.29.2)
-
-envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))


### PR DESCRIPTION
## Summary

Replace the legacy `setup-envtest` binary approach with the centralized `ensure-envtest.sh` script from [open-cluster-management-io/sdk-go](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/README-envtest.md).

### Changes

**Makefile:**
- Removed legacy `ENVTEST` and `ENVTEST_K8S_VERSION` variables and the `envtest` target that downloaded `setup-envtest` via `go install`
- Added new `envtest-setup` target using the centralized `ensure-envtest.sh` script from sdk-go
- The script auto-detects the Kubernetes version from `go.mod`, handles `setup-envtest` installation, and manages envtest binary downloads with proper version fallback logic
- Updated `test` target to depend on `envtest-setup` instead of `envtest`
- Removed outdated SHELL comment referencing `setup-envtest.sh`

**.gitignore:**
- Added `_output/` directory (default binary storage location used by the new `ensure-envtest.sh` script)

### Benefits
- Centralized envtest setup management across OCM repos
- Automatic K8s version detection from `go.mod` (no more hardcoded versions)
- Proper version fallback logic (exact → major.minor → latest)
- Enforces minimum `release-0.19` of setup-envtest to avoid deprecated GCS access errors

## Related issue(s)

N/A