### PR TITLE
:seedling: Update envtest setup to use sdk-go ensure-envtest.sh [backplane-2.9]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,7 @@
 
 # Test binary, built with `go test -c`
 bin
-testbin/*
+_output/
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ export CGO_ENABLED = 1
 export GOFLAGS ?=
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
@@ -55,11 +54,15 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-ENVTEST_ASSETS_DIR=$(shell pwd)/testbin
-test: manifests generate fmt vet ## Run tests.
-	mkdir -p ${ENVTEST_ASSETS_DIR}
-	test -f ${ENVTEST_ASSETS_DIR}/setup-envtest.sh || curl -sSLo ${ENVTEST_ASSETS_DIR}/setup-envtest.sh https://raw.githubusercontent.com/kubernetes-sigs/controller-runtime/v0.8.3/hack/setup-envtest.sh
-	source ${ENVTEST_ASSETS_DIR}/setup-envtest.sh; setup_envtest_env $(ENVTEST_ASSETS_DIR); go test ./pkg/... -coverprofile cover.out
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+test: manifests generate fmt vet envtest-setup ## Run tests.
+	go test ./pkg/... -coverprofile cover.out
 
 ##@ Build
 
@@ -130,7 +133,7 @@ images:
 images-amd64:
 	$(DOCKER_BUILDER) build --platform linux/amd64 -t ${IMG_REGISTRY}/managed-serviceaccount:${IMAGE_TAG} -f Dockerfile .
 
-test-integration:
+test-integration: envtest-setup
 	@echo "TODO: Run integration test"
 
 test-e2e: build-e2e


### PR DESCRIPTION
## Summary

Replace the legacy `setup-envtest.sh` script (downloaded from `controller-runtime v0.8.3`) with the new `ensure-envtest.sh` from `open-cluster-management-io/sdk-go`. This modernizes how envtest binaries (kube-apiserver, etcd, kubectl) are provisioned for unit and integration tests.

### Changes

- **Makefile**: Replace the old `ENVTEST_ASSETS_DIR` / `setup-envtest.sh` approach with the new `envtest-setup` target that uses `ensure-envtest.sh` from sdk-go. The new script automatically detects the K8s version from `go.mod`, determines the correct `setup-envtest` branch from the `controller-runtime` dependency, and exports `KUBEBUILDER_ASSETS`.
- **Makefile**: Add `envtest-setup` as a dependency to `test` and `test-integration` targets.
- **Makefile**: Remove outdated comment referencing the old `setup-envtest.sh` requirement.
- **.gitignore**: Replace `testbin/*` (old envtest binary cache) with `_output/` (new default binary directory used by `ensure-envtest.sh`).

### Benefits

- Automatic version detection from `go.mod` dependencies
- Fallback resolution strategy (exact match → minor-version wildcard → latest)
- Uses GitHub releases index instead of deprecated GCS buckets
- Consistent envtest setup across OCM projects

## Related issue(s)

N/A