### PR TITLE
🌱 Replace setup-envtest with sdk-go ensure-envtest.sh [backplane-2.11]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # Test binary, built with `go test -c`
 bin
 testbin/*
+_output/
 *.test
 
 # Output of the go coverage tool, specifically when used with LiteIDE

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ export CGO_ENABLED = 1
 export GOFLAGS ?=
 
 # Setting SHELL to bash allows bash commands to be executed by recipes.
-# This is a requirement for 'setup-envtest.sh' in the test target.
 # Options are set to exit when a recipe line exits non-zero or a piped command fails.
 SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
@@ -55,10 +54,15 @@ fmt: ## Run go fmt against code.
 vet: ## Run go vet against code.
 	go vet ./...
 
-ENVTEST = $(shell pwd)/bin/setup-envtest
-ENVTEST_K8S_VERSION = 1.35.0
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(shell pwd)/testbin -p path)" go test ./pkg/... -coverprofile cover.out
+ENSURE_ENVTEST_SCRIPT := https://raw.githubusercontent.com/open-cluster-management-io/sdk-go/main/ci/envtest/ensure-envtest.sh
+
+.PHONY: envtest-setup
+envtest-setup:
+	$(eval export KUBEBUILDER_ASSETS=$(shell curl -fsSL $(ENSURE_ENVTEST_SCRIPT) | bash))
+	@echo "KUBEBUILDER_ASSETS=$(KUBEBUILDER_ASSETS)"
+
+test: manifests generate fmt vet envtest-setup ## Run tests.
+	go test ./pkg/... -coverprofile cover.out
 
 ##@ Build
 
@@ -109,9 +113,6 @@ INFORMER_GEN = $(shell pwd)/bin/informer-gen
 informer-gen: ## Download informer-gen locally if necessary.
 	$(call go-get-tool,$(INFORMER_GEN),k8s.io/code-generator/cmd/informer-gen@v0.29.2)
 
-envtest: ## Download envtest-setup locally if necessary.
-	$(call go-get-tool,$(ENVTEST),sigs.k8s.io/controller-runtime/tools/setup-envtest@latest)
-
 # go-get-tool will 'go get' any package $2 and install it to $1.
 PROJECT_DIR := $(shell dirname $(abspath $(lastword $(MAKEFILE_LIST))))
 define go-get-tool
@@ -132,7 +133,7 @@ images:
 images-amd64:
 	$(DOCKER_BUILDER) build --platform linux/amd64 -t ${IMG_REGISTRY}/managed-serviceaccount:${IMAGE_TAG} -f Dockerfile .
 
-test-integration:
+test-integration: envtest-setup
 	@echo "TODO: Run integration test"
 
 test-e2e: build-e2e


### PR DESCRIPTION
## Summary

- Replace the legacy `setup-envtest` binary installation (via `go-get-tool`) with the centralized [`ensure-envtest.sh`](https://github.com/open-cluster-management-io/sdk-go/blob/main/ci/envtest/ensure-envtest.sh) script from `open-cluster-management-io/sdk-go`
- The new approach auto-detects K8s version and controller-runtime branch from `go.mod`, eliminating hardcoded `ENVTEST_K8S_VERSION` and manual `setup-envtest` binary management
- Add `_output/` to `.gitignore` for the new default binary storage directory
- Add `envtest-setup` as prerequisite to `test-integration` target

## Changes

| File | Change |
|------|--------|
| `Makefile` | Replace `ENVTEST`/`ENVTEST_K8S_VERSION` vars and `envtest` target with `ENSURE_ENVTEST_SCRIPT` and `envtest-setup` target |
| `Makefile` | Update `test` target to depend on `envtest-setup` instead of `envtest` |
| `Makefile` | Add `envtest-setup` prerequisite to `test-integration` |
| `Makefile` | Remove outdated `setup-envtest.sh` comment |
| `.gitignore` | Add `_output/` directory for envtest binary cache |

## Related issue(s)

Related to sdk-go envtest setup standardization: https://github.com/open-cluster-management-io/sdk-go/tree/main/ci/envtest

🤖 Generated with [Claude Code](https://claude.com/claude-code)