### PR TITLE
:bug: [sync] Replace deprecated kubebuilder-release-tools action with inline PR title validation

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -3,11 +3,7 @@
 name: PR Verifier
 
 on:
-  # NB: using `pull_request_target` runs this in the context of
-  # the base repository, so it has permission to upload to the checks API.
-  # This means changes won't kick in to this file until merged onto the
-  # main branch.
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize]
     branches:
       - main
@@ -19,13 +15,28 @@ permissions:
 jobs:
   verify:
     name: verify PR contents
-    permissions:
-      checks: write
-      pull-requests: read
     runs-on: ubuntu-latest
     steps:
       - name: Verifier action
-        id: verifier
-        uses: kubernetes-sigs/kubebuilder-release-tools@v0.4.3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [[ -z "$TITLE" ]]; then
+            echo "Error: PR title cannot be empty."
+            exit 1
+          fi
+
+          if ! [[ "$TITLE" =~ ^(:sparkles:|:bug:|:book:|:memo:|:warning:|:seedling:|:question:|$'\u2728'|$'\U0001F41B'|$'\U0001F4D6'|$'\U0001F4DD'|$'\u26A0'$'\uFE0F'?|$'\U0001F331'|$'\u2753') ]]; then
+            echo "Error: Invalid PR title format."
+            echo "Your PR title must start with one of the following indicators:"
+            echo "- :sparkles: ✨ feature"
+            echo "- :bug: 🐛 bug fix"
+            echo "- :book: 📖 docs"
+            echo "- :memo: 📝 proposal"
+            echo "- :warning: ⚠️ breaking change"
+            echo "- :seedling: 🌱 other/misc"
+            echo "- :question: ❓ requires manual review"
+            exit 1
+          fi
+
+          echo "PR title is valid: '$TITLE'"


### PR DESCRIPTION
Synced from upstream PR: https://github.com/open-cluster-management-io/managed-serviceaccount/pull/281

## Upstream PR Details
- **PR Number**: open-cluster-management-io/managed-serviceaccount#281
- **Author**: @zhujian7
- **Merged**: 2026-03-31
- **Commit**: 2500879a5a879d7aabcc7a14d437aaa797a5db3a

## Changes
Replace deprecated kubebuilder-release-tools action with inline PR title validation

---
This PR is part of the regular sync from the upstream open-cluster-management-io/managed-serviceaccount repository.

🤖 Generated by sync script