### PR TITLE
:seedling: [sync] Bump the github-actions group across 1 directory with 2 updates

### DIFF
--- a/.github/workflows/go-presubmit.yml
+++ b/.github/workflows/go-presubmit.yml
@@ -43,7 +43,7 @@ jobs:
       - name: unit
         run: make test
       - name: report coverage
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_UPLOAD_TOKEN }}
           files: ./cover.out

--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: setup helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
       - name: chart package
         run: |
           mkdir -p release


### PR DESCRIPTION
Synced from upstream PR: https://github.com/open-cluster-management-io/managed-serviceaccount/pull/280

## Upstream PR Details
- **PR Number**: open-cluster-management-io/managed-serviceaccount#280
- **Author**: @dependabot[bot]
- **Merged**: 2026-03-31
- **Commit**: abc1c380cf3aa6ef79839d50c1e5d5c776833ede

## Changes
Bump the github-actions group across 1 directory with 2 updates

---
This PR is part of the regular sync from the upstream open-cluster-management-io/managed-serviceaccount repository.

🤖 Generated by sync script