### PR TITLE
:seedling: Add FIPS flag to Konflux Dockerfile

### DIFF
--- a/Dockerfile.rhtap
+++ b/Dockerfile.rhtap
@@ -2,7 +2,7 @@ FROM brew.registry.redhat.io/rh-osbs/openshift-golang-builder:rhel_9_1.25 AS bui
 WORKDIR /go/src/github.com/open-cluster-management.io/managed-serviceaccount
 COPY . .
 RUN go env
-RUN make build-bin
+RUN GOEXPERIMENT=strictfipsruntime make build-bin
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 LABEL \


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:rocket: 🚀 release
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

- Add GOEXPERIMENT=strictfipsruntime to the Konflux Dockerfile.rhtap build for the managed-serviceaccount image.
Addresses [HYPBLD-844](https://redhat.atlassian.net/browse/HYPBLD-844) FIPS build flag requirements.

## Related issue(s)

[HYPBLD-844](https://redhat.atlassian.net/browse/HYPBLD-844)




[HYPBLD-844]: https://redhat.atlassian.net/browse/HYPBLD-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HYPBLD-844]: https://redhat.atlassian.net/browse/HYPBLD-844?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ