### PR TITLE
Bump jsonschema/v6 to fix Konflux build (.swp removal)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -63,7 +63,7 @@ require (
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.66.1 // indirect
 	github.com/prometheus/procfs v0.16.1 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.3-0.20260305113123-180cde331deb // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,8 @@ github.com/prometheus/procfs v0.16.1/go.mod h1:teAbpZRB1iIAJYREa1LsoWUXykVXA1KlT
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3-0.20260305113123-180cde331deb h1:gBKmvepO0IIyV3orONHHq+aOYjvDu7GFrJ9sXQ8RNSg=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.3-0.20260305113123-180cde331deb/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/shopspring/decimal v1.4.0 h1:bxl37RwXBklmTi0C79JfXCEBD1cqqHt0bbgBAGFp81k=
 github.com/shopspring/decimal v1.4.0/go.mod h1:gawqmDU56v4yIKSwfBSFip1HdCCXN8/+DMd9qYNcwME=
 github.com/spf13/cast v1.7.0 h1:ntdiHjuueXFgm5nzDRdOS4yfT43P5Fnud6DH50rz/7w=

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/format.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/format.go
@@ -318,7 +318,7 @@ func validateEmail(v any) error {
 		return LocalizableError("local part more than 64 characters long")
 	}
 
-	if len(local) > 1 && strings.HasPrefix(local, `"`) && strings.HasPrefix(local, `"`) {
+	if len(local) > 1 && strings.HasPrefix(local, `"`) && strings.HasSuffix(local, `"`) {
 		// quoted
 		local := local[1 : len(local)-1]
 		if strings.IndexByte(local, '\\') != -1 || strings.IndexByte(local, '"') != -1 {

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/go.work.sum
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/go.work.sum
@@ -1,4 +1,4 @@
-github.com/santhosh-tekuri/jsonschema/v6 v6.0.1/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 golang.org/x/mod v0.8.0/go.mod h1:iBbtSCu2XBx23ZKBPSOrRkjjQPZFPuis4dIYUhu/chs=
 golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/tools v0.6.0/go.mod h1:Xwgl3UAJ/d3gWutnCtw505GrjyAbvKui8lOU390QaIU=

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/objcompiler.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/objcompiler.go
@@ -355,9 +355,13 @@ func (c *objCompiler) enqueueRef(pname string) (*Schema, error) {
 	if ref == nil {
 		return nil, nil
 	}
+	return c.enqueueRefVal(*ref)
+}
+
+func (c *objCompiler) enqueueRefVal(ref string) (*Schema, error) {
 	baseURL := c.res.id
 	// baseURL := c.r.baseURL(c.up.ptr)
-	uf, err := baseURL.join(*ref)
+	uf, err := baseURL.join(ref)
 	if err != nil {
 		return nil, err
 	}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/schema.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/schema.go
@@ -1,8 +1,25 @@
+/*
+Package jsonschema provides json-schema compilation and validation.
+
+The schema is compiled against the version specified in "$schema" property.
+If "$schema" property is missing, it uses latest draft which currently implemented
+by this library.
+
+You can force to use specific draft,  when "$schema" is missing, as follows:
+
+	compiler := jsonschema.NewCompiler()
+	compiler.DefaultDraft(jsonschema.Draft4)
+
+This package supports loading json-schema from filePath and fileURL.
+
+see examples for usage.
+*/
 package jsonschema
 
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 )
 
@@ -110,12 +127,22 @@ const (
 )
 
 func typeOf(v any) jsonType {
-	switch v.(type) {
+	switch v := v.(type) {
 	case nil:
 		return nullType
 	case bool:
 		return booleanType
-	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+	case float64:
+		if math.IsNaN(v) || math.IsInf(v, 0) {
+			return invalidType
+		}
+		return numberType
+	case float32:
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			return invalidType
+		}
+		return numberType
+	case json.Number, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
 		return numberType
 	case string:
 		return stringType

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/util.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/util.go
@@ -320,6 +320,9 @@ func equals(v1, v2 any) (bool, ErrorKind) {
 		v2, ok := v2.(string)
 		return ok && v1 == v2, nil
 	case json.Number, float32, float64, int, int8, int16, int32, int64, uint, uint8, uint16, uint32, uint64:
+		if typeOf(v2) != numberType {
+			return false, nil
+		}
 		num1, ok1 := new(big.Rat).SetString(fmt.Sprint(v1))
 		num2, ok2 := new(big.Rat).SetString(fmt.Sprint(v2))
 		return ok1 && ok2 && num1.Cmp(num2) == 0, nil

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/validator.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/validator.go
@@ -375,7 +375,7 @@ func (vd *validator) arrValidate(arr []any) {
 				}
 			case *Schema:
 				for i, item := range arr[evaluated:] {
-					vd.addErr(vd.validateVal(additional, item, strconv.Itoa(i)))
+					vd.addErr(vd.validateVal(additional, item, strconv.Itoa(evaluated+i)))
 				}
 			}
 		}
@@ -390,7 +390,7 @@ func (vd *validator) arrValidate(arr []any) {
 		// items2020 --
 		if s.Items2020 != nil {
 			for i, item := range arr[evaluated:] {
-				vd.addErr(vd.validateVal(s.Items2020, item, strconv.Itoa(i)))
+				vd.addErr(vd.validateVal(s.Items2020, item, strconv.Itoa(evaluated+i)))
 			}
 		}
 	}

--- a/vendor/github.com/santhosh-tekuri/jsonschema/v6/vocab.go
+++ b/vendor/github.com/santhosh-tekuri/jsonschema/v6/vocab.go
@@ -14,6 +14,10 @@ func (ctx *CompilerContext) Enqueue(schPath []string) *Schema {
 	return ctx.c.enqueuePtr(ptr)
 }
 
+func (ctx *CompilerContext) EnqueueRef(ref string) (*Schema, error) {
+	return ctx.c.enqueueRefVal(ref)
+}
+
 // Vocabulary defines a set of keywords, their syntax and
 // their semantics.
 type Vocabulary struct {

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -194,7 +194,7 @@ github.com/prometheus/common/model
 github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
-# github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
+# github.com/santhosh-tekuri/jsonschema/v6 v6.0.3-0.20260305113123-180cde331deb
 ## explicit; go 1.21
 github.com/santhosh-tekuri/jsonschema/v6
 github.com/santhosh-tekuri/jsonschema/v6/kind


### PR DESCRIPTION
## Summary

- Pins `github.com/santhosh-tekuri/jsonschema/v6` to commit `180cde3` (pseudo-version `v6.0.3-0.20260305113123-180cde331deb`) which removes an accidentally included Vim swap file (`.swp`).
- The `.swp` file in `v6.0.2` causes Hermeto/cachi2 strict-mode vendor validation to fail during Konflux builds because `managed-serviceaccount`'s `.gitignore` excludes `*.swp`, making the vendor directory inconsistent after `go mod vendor`.
- Upstream fix: https://github.com/santhosh-tekuri/jsonschema/pull/254 (merged, not yet released)
- Once `v6.0.3` is tagged upstream, this should be bumped to the official release.

## Test plan

- [ ] Verify Konflux build passes (prefetch-dependencies task no longer fails on vendor validation)

Made with [Cursor](https://cursor.com)