### PR TITLE
:seedling: [sync] Add delete verb to secrets RBAC for ownerReference updates (#336)

### DIFF
--- a/charts/managed-serviceaccount/templates/agent-registration-clusterrole.yaml
+++ b/charts/managed-serviceaccount/templates/agent-registration-clusterrole.yaml
@@ -14,6 +14,7 @@ rules:
   - watch
   - create
   - update
+  - delete
 - apiGroups:
   - authentication.open-cluster-management.io
   resources:

--- a/charts/managed-serviceaccount/templates/clusterrole.yaml
+++ b/charts/managed-serviceaccount/templates/clusterrole.yaml
@@ -108,6 +108,7 @@ rules:
       - watch
       - create
       - update
+      - delete
   - apiGroups:
       - ""
     resources:

--- a/deploy/bases/hub-clusterrole.yaml
+++ b/deploy/bases/hub-clusterrole.yaml
@@ -13,6 +13,7 @@ rules:
   - watch
   - create
   - update
+  - delete
 - apiGroups:
   - authentication.open-cluster-management.io
   resources:

--- a/pkg/addon/manager/addon.go
+++ b/pkg/addon/manager/addon.go
@@ -70,7 +70,7 @@ func setupPermission(nativeClient kubernetes.Interface) agent.PermissionConfigFu
 			Rules: []rbacv1.PolicyRule{
 				{
 					APIGroups: []string{""},
-					Verbs:     []string{"get", "list", "watch", "create", "update"},
+					Verbs:     []string{"get", "list", "watch", "create", "update", "delete"},
 					Resources: []string{"secrets"},
 				},
 				{


### PR DESCRIPTION
Cherry-pick of upstream PR: open-cluster-management-io/managed-serviceaccount#336

## Summary

The `OwnerReferencesPermissionEnforcement` admission plugin requires `delete` permission on the child resource when modifying `ownerReferences` during an Update operation. After backup/restore, the `ManagedServiceAccount` CR gets a new UID, causing the token controller to update the `ownerReference` on the token secret — which fails without `delete` permission.

Add the `delete` verb to the secrets RBAC rules in all deployment paths.

Fixes: https://redhat.atlassian.net/browse/ACM-38215